### PR TITLE
Forward fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Download and install just like any other WordPress plugin. If you want to be rea
 
 ## Changelog
 
+### 0.7.0-dev - YYYY.MM.DD
+ * Tweak - Remove dependency on WooCommerce
+
 ### 0.7.0 - 2017.04.12
  * Feature - Use the Bogus gateway for Subscriptions automatic renewals
  * Fix - Subscriptions integration throwing a warning in WooCommerce 3.0+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Download and install just like any other WordPress plugin. If you want to be rea
 
 ## Changelog
 
-### 0.7.0-dev - YYYY.MM.DD
+### 0.7.1-dev - YYYY.MM.DD
  * Tweak - Remove dependency on WooCommerce
  * Tweak - Add support for domain forwarding as early as possible
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Download and install just like any other WordPress plugin. If you want to be rea
 
 ### 0.7.0-dev - YYYY.MM.DD
  * Tweak - Remove dependency on WooCommerce
+ * Tweak - Add support for domain forwarding as early as possible
 
 ### 0.7.0 - 2017.04.12
  * Feature - Use the Bogus gateway for Subscriptions automatic renewals

--- a/i18n/languages/woocommerce-dev-helper.pot
+++ b/i18n/languages/woocommerce-dev-helper.pot
@@ -1,17 +1,77 @@
-# Copyright (C) 2016 SkyVerge
+# Copyright (C) 2017 SkyVerge
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Dev Helper 0.4.2\n"
+"Project-Id-Version: A WooCommerce Dev Helper 0.7.0-dev\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-dev-helper/issues\n"
 "POT-Creation-Date: 2015-07-26 19:51:27+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:42
+msgid "Bogus"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:43
+msgid ""
+"A testing gateway that calls \"payment complete\" to simulate credit card "
+"transactions."
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:92
+msgid "Enable/Disable"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:94
+msgid "Enable Bogus Gateway"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:99
+msgid "Title"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:101
+msgid ""
+"This controls the title for the payment method the customer sees during "
+"checkout."
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:102
+msgid "Bogus (Test)"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:107
+msgid "Description"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:109
+msgid "Payment method description that the customer will see on your checkout."
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:110
+msgid "Nothingtodohere &#128640;"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:115
+msgid "Enable Subscriptions support?"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:117
+msgid "Makes the gateway available for subscriptions purchases"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:150
+msgid "Bogus is always approved &#128526;"
+msgstr ""
+
+#: includes/class-wc-dev-helper-bogus-gateway.php:175
+msgid "Renewal order processed. Bogus is always approved &#128526;"
+msgstr ""
 
 #: includes/class-wc-dev-helper-memberships.php:55
 msgid "minute(s)"
@@ -21,32 +81,32 @@ msgstr ""
 msgid "hour(s)"
 msgstr ""
 
-#: includes/class-wc-dev-helper-subscriptions.php:97
+#: includes/class-wc-dev-helper-subscriptions.php:98
 msgid "Renew"
 msgstr ""
 
-#: includes/class-wc-dev-helper-subscriptions.php:150
+#: includes/class-wc-dev-helper-subscriptions.php:151
 msgid "Subscription renewal processed. %sView Renewal Order%s"
 msgstr ""
 
-#: includes/class-wc-dev-helper-subscriptions.php:173
+#: includes/class-wc-dev-helper-subscriptions.php:174
 msgid "Action Failed, Invalid Nonce"
 msgstr ""
 
-#: includes/class-wc-dev-helper-subscriptions.php:202
+#: includes/class-wc-dev-helper-subscriptions.php:203
 msgid "Subscription Renewal Processed"
 msgstr ""
 
-#: woocommerce-dev-helper.php:261
+#: woocommerce-dev-helper.php:346
 msgid "You cannot clone instances of WooCommerce Dev Helper."
 msgstr ""
 
-#: woocommerce-dev-helper.php:271
+#: woocommerce-dev-helper.php:356
 msgid "You cannot unserialize instances of WooCommerce Dev Helper."
 msgstr ""
 
 #. Plugin Name of the plugin/theme
-msgid "WooCommerce Dev Helper"
+msgid "A WooCommerce Dev Helper"
 msgstr ""
 
 #. Plugin URI of the plugin/theme

--- a/i18n/languages/woocommerce-dev-helper.pot
+++ b/i18n/languages/woocommerce-dev-helper.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: A WooCommerce Dev Helper 0.7.0-dev\n"
+"Project-Id-Version: A WooCommerce Dev Helper 0.7.1-dev\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/skyverge/woocommerce-dev-helper/issues\n"
 "POT-Creation-Date: 2015-07-26 19:51:27+00:00\n"

--- a/includes/class-wc-dev-helper-bogus-gateway.php
+++ b/includes/class-wc-dev-helper-bogus-gateway.php
@@ -18,6 +18,10 @@
 
 defined( 'ABSPATH' ) or exit;
 
+if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
+	return;
+}
+
 /**
  * Adds a testing gateway that calls the WooCommerce payment_complete() method.
  *

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "woocommerce-dev-helper",
+	"name": "a-woocommerce-dev-helper",
 	"version": "0.7.0-dev",
 	"author": "SkyVerge Team",
 	"homepage": "http://www.skyverge.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-dev-helper",
-	"version": "0.5.0",
+	"version": "0.7.0-dev",
 	"author": "SkyVerge Team",
 	"homepage": "http://www.skyverge.com",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "a-woocommerce-dev-helper",
-	"version": "0.7.0-dev",
+	"version": "0.7.1-dev",
 	"author": "SkyVerge Team",
 	"homepage": "http://www.skyverge.com",
 	"repository": {

--- a/woocommerce-dev-helper.php
+++ b/woocommerce-dev-helper.php
@@ -5,7 +5,7 @@
  * Description: A simple plugin for helping develop/debug WooCommerce & extensions
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 0.7.0-dev
+ * Version: 0.7.1-dev
  * Text Domain: woocommerce-dev-helper
  * Domain Path: /i18n/languages/
  *

--- a/woocommerce-dev-helper.php
+++ b/woocommerce-dev-helper.php
@@ -5,7 +5,7 @@
  * Description: A simple plugin for helping develop/debug WooCommerce & extensions
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 0.7.0
+ * Version: 0.7.0-dev
  * Text Domain: woocommerce-dev-helper
  * Domain Path: /i18n/languages/
  *
@@ -69,7 +69,9 @@ class WC_Dev_Helper {
 
 		// add some inline JS
 		add_action( 'wp_footer', array( $this, 'enqueue_scripts' ) );
-		add_action( 'wp_head',   array( $this, 'bogus_gateway_styles' ) );
+		if ( $this->is_plugin_active( 'woocommerce.php' ) ) {
+			add_action( 'wp_head',   array( $this, 'bogus_gateway_styles' ) );
+		}
 
 		// add the testing gateway
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_bogus_gateway' ) );
@@ -142,8 +144,8 @@ class WC_Dev_Helper {
 			$this->ajax    = new WC_Dev_Helper_Ajax();
 		}
 
-		require_once( $this->get_plugin_path() . '/includes/class-wc-dev-helper-bogus-gateway.php' );
 		if ( $this->is_plugin_active( 'woocommerce.php' ) ) {
+			require_once( $this->get_plugin_path() . '/includes/class-wc-dev-helper-bogus-gateway.php' );
 			$this->gateway = new WC_Bogus_Gateway();
 		}
 

--- a/woocommerce-dev-helper.php
+++ b/woocommerce-dev-helper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Dev Helper
+ * Plugin Name: A WooCommerce Dev Helper
  * Plugin URI: https://github.com/skyverge/woocommerce-dev-helper/
  * Description: A simple plugin for helping develop/debug WooCommerce & extensions
  * Author: SkyVerge
@@ -75,6 +75,10 @@ class WC_Dev_Helper {
 
 		// add the testing gateway
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_bogus_gateway' ) );
+
+		// use forwarded URLs: this needs to be done as early as possible in order to set the $_SERVER['HTTPS'] var
+		require_once( $this->get_plugin_path() . '/includes/class-wc-dev-helper-use-forwarded-urls.php' );
+		$this->use_forwarded_urls = new WC_Dev_Helper_Use_Forwarded_URLs();
 	}
 
 
@@ -148,10 +152,6 @@ class WC_Dev_Helper {
 			require_once( $this->get_plugin_path() . '/includes/class-wc-dev-helper-bogus-gateway.php' );
 			$this->gateway = new WC_Bogus_Gateway();
 		}
-
-		// use forwarded URLs
-		require_once( $this->get_plugin_path() . '/includes/class-wc-dev-helper-use-forwarded-urls.php' );
-		$this->use_forwarded_urls = new WC_Dev_Helper_Use_Forwarded_URLs();
 
 		if ( $this->is_plugin_active( 'woocommerce-subscriptions.php' ) ) {
 


### PR DESCRIPTION
# Overview

Remove dependency on WooCommerce, and improve domain forwarding support for HTTPS requests.

These changes were made so that this plugin could be used while developing Jilt for EDD

## Details

Previously some fatals occurred if the WooCommerce plugin were not active.

These changes ensure that the code that adds support for domain forwarding needs to be executed as _early_ as possible so as to set the `$_SERVER['HTTPS']` env var before any other core or plugin code needs it.

In order to achieve this, the installed/active plugin directory should be named `a-woocommerce-dev-helper` so that it's executed before all other plugins. Otherwise with EDD for instance, a bunch of external files will be loaded over HTTP and raise mixed content errors when forwarding over HTTPS
