### PR TITLE
Fix get_forwarded_host() when HTTP_X_FORWARDED_HOST is defined

### DIFF
--- a/includes/Forwarded_URLs.php
+++ b/includes/Forwarded_URLs.php
@@ -135,10 +135,10 @@ class Forwarded_URLs {
 	public function get_forwarded_host() {
 
 		// are we using Forward HQ?
-		$host = isset( $_SERVER['HTTP_X_FORWARDED_HOST'] ) ? $_SERVER['HTTP_X_FORWARDED_HOST'] :  false;
+		$host = isset( $_SERVER['HTTP_X_FORWARDED_HOST'] ) ? $_SERVER['HTTP_X_FORWARDED_HOST'] : $_SERVER['HTTP_HOST'];
 
 		// if not, check if we're using ngrok
-		$host = ! $host && isset( $_SERVER['HTTP_X_ORIGINAL_HOST'] ) ? $_SERVER['HTTP_X_ORIGINAL_HOST'] : $_SERVER['HTTP_HOST'];
+		$host = isset( $_SERVER['HTTP_X_ORIGINAL_HOST'] ) ? $_SERVER['HTTP_X_ORIGINAL_HOST'] : $host;
 
 		return $host;
 	}


### PR DESCRIPTION
I run into an issue with `get_forwarded_host()` while using ngrok to expose a Valet website using `valet share`:

If `$_SERVER['HTTP_X_FORWARDED_HOST']` is defined, `get_forwarded_host()` always returns the value from `$_SERVER['HTTP_HOST']`.

It looks like [Valet adds](https://github.com/laravel/valet/blob/7011629b41a5b3f9cc3a8551443a377afd0549a1/server.php#L117-L122) the X-Forwarded-Host header when ngrok is used, so in my case both `$_SERVER['HTTP_X_FORWARDED_HOST']` and `$_SERVER['HTTP_X_ORIGINAL_HOST']` were defined and the dev helper was not using them.