### PR TITLE
Add payment result options

### DIFF
--- a/includes/Bogus_Gateway.php
+++ b/includes/Bogus_Gateway.php
@@ -32,6 +32,16 @@ if ( ! class_exists( '\\WC_Payment_Gateway' ) ) {
 class Bogus_Gateway extends \WC_Payment_Gateway {
 
 
+	/** @var string the "accepted" payment result code */
+	const PAYMENT_RESULT_APPROVED = 'approved';
+
+	/** @var string the "declined" payment result code */
+	const PAYMENT_RESULT_DECLINED = 'declined';
+
+	/** @var string the "held" payment result code */
+	const PAYMENT_RESULT_HELD = 'held';
+
+
 	/** @var string subscriptions setting */
 	private $subscriptions;
 
@@ -127,6 +137,27 @@ class Bogus_Gateway extends \WC_Payment_Gateway {
 			),
 
 		) );
+	}
+
+
+	/**
+	 * Renders the gateway payment fields.
+	 *
+	 * @since x.y.z
+	 */
+	public function payment_fields() {
+
+		parent::payment_fields();
+
+		woocommerce_form_field( "{$this->id}_payment_result", [
+			'type'  => 'select',
+			'label' => __( 'Result', 'woocommerce-dev-helper' ),
+			'options' => [
+				self::PAYMENT_RESULT_APPROVED => __( 'Approved', 'woocommerce-dev-helper' ),
+				self::PAYMENT_RESULT_DECLINED => __( 'Declined', 'woocommerce-dev-helper' ),
+				self::PAYMENT_RESULT_HELD     => __( 'Held', 'woocommerce-dev-helper' ),
+			],
+		] );
 	}
 
 

--- a/includes/Bogus_Gateway.php
+++ b/includes/Bogus_Gateway.php
@@ -150,12 +150,13 @@ class Bogus_Gateway extends \WC_Payment_Gateway {
 		parent::payment_fields();
 
 		woocommerce_form_field( "{$this->id}_payment_result", [
-			'type'  => 'select',
-			'label' => __( 'Result', 'woocommerce-dev-helper' ),
-			'options' => [
+			'type'     => 'select',
+			'label'    => __( 'Result', 'woocommerce-dev-helper' ),
+			'required' => true,
+			'options'  => [
 				self::PAYMENT_RESULT_APPROVED => __( 'Approved', 'woocommerce-dev-helper' ),
-				self::PAYMENT_RESULT_DECLINED => __( 'Declined', 'woocommerce-dev-helper' ),
 				self::PAYMENT_RESULT_HELD     => __( 'Held', 'woocommerce-dev-helper' ),
+				self::PAYMENT_RESULT_DECLINED => __( 'Declined', 'woocommerce-dev-helper' ),
 			],
 		] );
 	}


### PR DESCRIPTION
Allows testers to specify their desired payment result from the bogus gateway.

This is useful for quickly testing other plugins or snippets that handle orders differently depending on the payment status.

## QA
1. Enable the bogus gateway
1. Place an order with "Accepted" selected in the checkout payment field
    - [x] Order is Processing with a note added
1. Place an order with "Held" selected
    - [x] Order is On-Hold with a note added
1. Try to place an order with "Declined" selected
    - [x] Order is Failed with a note added
1. Switch to "Accepted" or "Held"
    - [x] Order succeeds with a new note added